### PR TITLE
Fix signature of Debugger.log() in 'debug'

### DIFF
--- a/types/debug/index.d.ts
+++ b/types/debug/index.d.ts
@@ -38,7 +38,7 @@ declare namespace debug {
         (formatter: any, ...args: any[]): void;
 
         enabled: boolean;
-        log: (v: any) => string;
+        log: (...args: any[]) => void;
         namespace: string;
         extend: (namespace: string, delimiter?: string) => Debugger;
     }


### PR DESCRIPTION
The value of `.log` is used with variadic arguments in the debug source and its return value is ignored, the signature should be one that allows i.e. `console.log`. The previous change broke correct code doing that.
